### PR TITLE
remove color codes from the message

### DIFF
--- a/SIbot.js
+++ b/SIbot.js
@@ -11,6 +11,9 @@ var irc = require("irc");
 var bot = new irc.Client(config.server, config.botName, { channels: config.channels });
 
 bot.addListener('message', function (from, to, message) {
+    // remove color codes from the message
+    message = message.replace(/[\x02\x1F\x0F\x16]|\x03(\d\d?(,\d\d?)?)?/g,'');
+    
     // List of parser functions
     // (more than one conversion can be output per input message)
     


### PR DESCRIPTION
Otherwise you get stuff like this:

```
18:44:22 <  SpacenearUS> lz1dev: Telemetry: Main 1.516 V Aux 0 V Temp 4.5 C Sat 11 # Alt 6310 ft
18:44:49 < theRealSIbot> In real units: 106310 ft = 32 km
```
